### PR TITLE
Fix CLI close unexpectedly when first login

### DIFF
--- a/src/commands/shell.js
+++ b/src/commands/shell.js
@@ -10,11 +10,7 @@ import putility from '@heyputer/putility';
 
 const config = new Conf({ projectName: PROJECT_NAME });
 
-export const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-  prompt: null
-});
+export let rl;
 
 /**
  * Update the current shell prompt
@@ -47,6 +43,12 @@ export async function startShell(command) {
     await execCommand(context, command);
     process.exit(0);
   }
+
+  rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: null
+  })
 
   try {
     console.log(chalk.green('Welcome to Puter-CLI! Type "help" for available commands.'));

--- a/src/modules/ProfileModule.js
+++ b/src/modules/ProfileModule.js
@@ -43,8 +43,6 @@ class ProfileModule {
             if ( ! config.get('selected_profile') ) {
                 console.log(chalk.cyan('Please login first (or use CTRL+C to exit):'));
                 await this.switchProfileWizard();
-                console.log(chalk.red('Please run "puter" command again (issue #11)'));
-                process.exit(0);
             }
             this.applyProfileToGlobals();
         });


### PR DESCRIPTION
Fixes #11 

- the issue only happens on first login, where we run `inquirer.prompt` before running `readline.prompt`
- seems like there is conflict on how each lib handles `process.stdin`
- how we were doing it was we init `rl`, then run `inquirer.prompt` which probably modify how the `stdin` works
- solving this by only initializing `rl` when we need it, and after we do `inquirer.prompt`
- every `rl` features still work normally, even the exported function