### PR TITLE
Update `/batch` drivers call to use `puter.fs.upload`

### DIFF
--- a/src/commands/files.js
+++ b/src/commands/files.js
@@ -572,7 +572,7 @@ export async function createFile(args = []) {
             }
         }
 
-        // Step 4: Create the file using /batch
+        // Step 4: Create the file
         const fileBlob = new Blob([content || ''], { type: 'text/plain' });
 
         const createData = await puter.fs.upload(fileBlob, dirName, {
@@ -1177,6 +1177,7 @@ export async function editFile(args = []) {
       
       // Read the updated content after editor closes
       const updatedContent = fs.readFileSync(tempFilePath, 'utf8');
+      const blob = new Blob([updatedContent]);
       console.log(chalk.cyan('Uploading changes...'));
       
       // Step 7: Upload the updated file content
@@ -1189,60 +1190,15 @@ export async function editFile(args = []) {
       }
 
       // Step 7.2: Uploading the updated file
-      const operationId = crypto.randomUUID(); // Generate a unique operation ID
-      const socketId = 'undefined'; // Placeholder socket ID
-      const boundary = `----WebKitFormBoundary${crypto.randomUUID().replace(/-/g, '')}`;
       const fileName = path.basename(filePath);
       const dirName = path.dirname(filePath);
 
-      // Prepare FormData
-      const formData = `--${boundary}\r\n` +
-          `Content-Disposition: form-data; name="operation_id"\r\n\r\n${operationId}\r\n` +
-          `--${boundary}\r\n` +
-          `Content-Disposition: form-data; name="socket_id"\r\n\r\n${socketId}\r\n` +
-          `--${boundary}\r\n` +
-          `Content-Disposition: form-data; name="original_client_socket_id"\r\n\r\n${socketId}\r\n` +
-          `--${boundary}\r\n` +
-          `Content-Disposition: form-data; name="fileinfo"\r\n\r\n${JSON.stringify({
-              name: fileName,
-              type: 'text/plain',
-              size: Buffer.byteLength(updatedContent, 'utf8')
-          })}\r\n` +
-          `--${boundary}\r\n` +
-          `Content-Disposition: form-data; name="operation"\r\n\r\n${JSON.stringify({
-              op: 'write',
-              dedupe_name: false,
-              overwrite: true,
-              operation_id: operationId,
-              path: dirName,
-              name: fileName,
-              item_upload_id: 0
-          })}\r\n` +
-          `--${boundary}\r\n` +
-          `Content-Disposition: form-data; name="file"; filename="${fileName}"\r\n` +
-          `Content-Type: text/plain\r\n\r\n${updatedContent}\r\n` +
-          `--${boundary}--\r\n`;
-
-      // Send the upload request
-      const uploadResponse = await fetch(`${API_BASE}/batch`, {
-          method: 'POST',
-          headers: getHeaders(`multipart/form-data; boundary=${boundary}`),
-          body: formData
+      const uploadData = await puter.fs.upload(blob, dirName, {
+        overwrite: true,
+        dedupeName: false,
+        name: fileName
       });
-
-      if (!uploadResponse.ok) {
-          const errorText = await uploadResponse.text();
-          console.log(chalk.red(`Failed to save file. Server response: ${errorText}`));
-          return;
-      }
-
-      const uploadData = await uploadResponse.json();
-      if (uploadData && uploadData.results && uploadData.results.length > 0) {
-          const file = uploadData.results[0];
-          console.log(chalk.green(`File saved: ${file.path}`));
-      } else {
-          console.log(chalk.red('Failed to save file. Invalid response from server.'));
-      }
+      console.log(chalk.green(`File saved: ${uploadData.path}`));
     } catch (error) {
       if (error.status === 130) {
         // This is a SIGINT (Ctrl+C), which is normal for some editors


### PR DESCRIPTION
Fixes #40 

- use `puter.fs.upload` for `push`
- use `puter.fs.upload` for `touch`
- use `puter.fs.upload` for `edit`