### PR TITLE
Fix puter module causing unref error

### DIFF
--- a/src/modules/PuterModule.js
+++ b/src/modules/PuterModule.js
@@ -1,4 +1,3 @@
-import { init } from "@heyputer/puter.js/src/init.cjs";
 import Conf from "conf";
 import { PROJECT_NAME } from "../commons.js";
 import { puter } from "@heyputer/puter.js";
@@ -13,7 +12,8 @@ export const initPuterModule = () => {
   const profile = profiles.find((v) => v.uuid === uuid);
   const authToken = profile?.token;
 
-  puterModule = init(authToken);
+  puter.setAuthToken(authToken);
+  puterModule = puter;
 };
 
 /**


### PR DESCRIPTION
Fixes #44 

tested working on node 20, 22, 24

- update code for init puter
- directly uses the puter.setAuthToken instead of the node specific init()